### PR TITLE
feat: Move DTO AssetMergeInfo

### DIFF
--- a/model/src/main/java/fish/focus/uvms/asset/remote/dto/AssetMergeInfo.java
+++ b/model/src/main/java/fish/focus/uvms/asset/remote/dto/AssetMergeInfo.java
@@ -1,10 +1,10 @@
-package fish.focus.uvms.asset.dto;
+package fish.focus.uvms.asset.remote.dto;
 
 public class AssetMergeInfo {
     String oldAssetId;
     String newAssetId;
 
-    public AssetMergeInfo(){
+    public AssetMergeInfo() {
 
     }
 

--- a/module/src/main/java/fish/focus/uvms/asset/message/EventStreamSender.java
+++ b/module/src/main/java/fish/focus/uvms/asset/message/EventStreamSender.java
@@ -1,11 +1,11 @@
 package fish.focus.uvms.asset.message;
 
+import fish.focus.uvms.asset.domain.entity.Asset;
+import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
 import fish.focus.uvms.commons.date.JsonBConfigurator;
 import fish.focus.uvms.commons.message.api.MessageConstants;
 import fish.focus.uvms.commons.message.context.MappedDiagnosticContext;
-import fish.focus.uvms.asset.domain.entity.Asset;
-import fish.focus.uvms.asset.dto.AssetMergeInfo;
-import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/module/src/main/java/fish/focus/uvms/mobileterminal/timer/AssetRemapTask.java
+++ b/module/src/main/java/fish/focus/uvms/mobileterminal/timer/AssetRemapTask.java
@@ -1,14 +1,15 @@
 package fish.focus.uvms.mobileterminal.timer;
 
-import javax.ejb.Stateless;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
 import fish.focus.uvms.asset.bean.AssetServiceBean;
 import fish.focus.uvms.asset.domain.dao.AssetDao;
 import fish.focus.uvms.asset.domain.entity.Asset;
 import fish.focus.uvms.asset.domain.entity.AssetRemapMapping;
-import fish.focus.uvms.asset.dto.AssetMergeInfo;
 import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
+
+import javax.ejb.Stateless;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;

--- a/module/src/main/java/fish/focus/uvms/rest/asset/service/SSEResource.java
+++ b/module/src/main/java/fish/focus/uvms/rest/asset/service/SSEResource.java
@@ -1,11 +1,11 @@
 package fish.focus.uvms.rest.asset.service;
 
+import fish.focus.uvms.asset.domain.entity.Asset;
+import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
 import fish.focus.uvms.commons.date.JsonBConfigurator;
 import fish.focus.uvms.rest.security.RequiresFeature;
 import fish.focus.uvms.rest.security.UnionVMSFeature;
-import fish.focus.uvms.asset.domain.entity.Asset;
-import fish.focus.uvms.asset.dto.AssetMergeInfo;
-import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/module/src/test/java/fish/focus/uvms/asset/message/EventStreamSenderTest.java
+++ b/module/src/test/java/fish/focus/uvms/asset/message/EventStreamSenderTest.java
@@ -5,12 +5,12 @@
  */
 package fish.focus.uvms.asset.message;
 
-import fish.focus.uvms.commons.date.JsonBConfigurator;
-import fish.focus.uvms.commons.message.api.MessageConstants;
 import fish.focus.uvms.asset.domain.dao.AssetDao;
 import fish.focus.uvms.asset.domain.entity.Asset;
 import fish.focus.uvms.asset.domain.entity.AssetRemapMapping;
-import fish.focus.uvms.asset.dto.AssetMergeInfo;
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
+import fish.focus.uvms.commons.date.JsonBConfigurator;
+import fish.focus.uvms.commons.message.api.MessageConstants;
 import fish.focus.uvms.mobileterminal.timer.AssetRemapTask;
 import fish.focus.uvms.tests.BuildAssetServiceDeployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;


### PR DESCRIPTION
By moving the DTO to a shared lib it can now be reused in other parts of UVMS to deserialize the event payload.

Refs: FART-530