### PR TITLE
test: removes powermock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <groupId>fish.focus.uvms.maven</groupId>
         <artifactId>uvms-pom</artifactId>
         <relativePath/>
-        <version>3.24</version>
+        <version>3.27</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <docker.liquibase.changeLogFile>LIQUIBASE/changelog/db-changelog-master.xml</docker.liquibase.changeLogFile>
         <docker.liquibase.db.user>asset</docker.liquibase.db.user>
         <docker.liquibase.db.passwd>asset</docker.liquibase.db.passwd>
-        <uvms.pom.version>3.24</uvms.pom.version>
+        <uvms.pom.version>3.27</uvms.pom.version>
         <usm4uvms.version>4.1.12</usm4uvms.version>
         <uvms.common.version>4.1.15</uvms.common.version>
         <uvms.config.version>4.1.6</uvms.config.version>


### PR DESCRIPTION
Powermock doesn't play well with newer versions of Mockito which now supports static mocking => remove powermock as a dependency.