### PR TITLE
fix: asset remapping check and logging

### DIFF
--- a/module/src/main/java/fish/focus/uvms/mobileterminal/timer/AssetRemapTask.java
+++ b/module/src/main/java/fish/focus/uvms/mobileterminal/timer/AssetRemapTask.java
@@ -6,6 +6,8 @@ import fish.focus.uvms.asset.domain.entity.Asset;
 import fish.focus.uvms.asset.domain.entity.AssetRemapMapping;
 import fish.focus.uvms.asset.message.event.UpdatedAssetEvent;
 import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ejb.Stateless;
 import javax.enterprise.event.Event;
@@ -17,6 +19,8 @@ import java.util.List;
 
 @Stateless
 public class AssetRemapTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AssetRemapTask.class);
 
     @Inject
     private AssetDao assetDao;
@@ -32,17 +36,27 @@ public class AssetRemapTask {
         List<AssetRemapMapping> mappings = assetDao.getAllAssetRemappings();
         List<AssetRemapMapping> deleteMappings = new ArrayList<>();
 
+        LOG.info("Checking {} asset re-mappings", mappings.size());
+
+        Instant threeHoursAgo = Instant.now().minus(3, ChronoUnit.HOURS);
+
         for (AssetRemapMapping mapping : mappings) {
             int remappedMovements = assetService.remapAssetsInMovement(mapping.getOldAssetId().toString(), mapping.getNewAssetId().toString());
-            if (remappedMovements == 0 && Instant.now().isAfter(mapping.getCreatedDate().plus(3, ChronoUnit.HOURS))) {
+            Instant createdDate = mapping.getCreatedDate();
+
+            if (remappedMovements == 0 && createdDate.isBefore(threeHoursAgo)) {
                 deleteMappings.add(mapping);
             }
         }
+
+        LOG.info("{} mappings should be deleted", deleteMappings.size());
+
         for (AssetRemapMapping mappingToBeDeleted : deleteMappings) {
             assetService.removeMovementConnectInMovement(mappingToBeDeleted.getOldAssetId().toString());
             assetDao.deleteAssetMapping(mappingToBeDeleted);
             Asset asset = assetDao.getAssetById(mappingToBeDeleted.getOldAssetId());
             if (asset != null) {
+                LOG.info("Asset {} has been fully remapped. Deleting from DB", asset);
                 assetDao.deleteAsset(asset);
                 updatedAssetEvent.fire(new AssetMergeInfo(mappingToBeDeleted.getOldAssetId().toString(), mappingToBeDeleted.getNewAssetId().toString()));
             }


### PR DESCRIPTION
The check was 3 adding hours after the isAfter check. The intent seems to have been to have a 3 hour grace period after the remap entry was made.

Introduces logging for asset remapping, in particular when deleting an asset.

Refs: FART-538