### PR TITLE
refactor: logs asset on upsert exception

### DIFF
--- a/module/src/main/java/fish/focus/uvms/asset/domain/entity/Asset.java
+++ b/module/src/main/java/fish/focus/uvms/asset/domain/entity/Asset.java
@@ -776,4 +776,21 @@ public class Asset implements Serializable {
     public void setParked(Boolean parked) {
         this.parked = parked;
     }
+
+    @Override
+    public String toString() {
+        return "Asset{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", cfr='" + cfr + '\'' +
+                ", imo='" + imo + '\'' +
+                ", nationalId=" + nationalId +
+                ", ircs='" + ircs + '\'' +
+                ", mmsi='" + mmsi + '\'' +
+                ", flagStateCode='" + flagStateCode + '\'' +
+                ", source='" + source + '\'' +
+                ", eventCode='" + eventCode + '\'' +
+                ", active=" + active +
+                '}';
+    }
 }


### PR DESCRIPTION
Improves logging for upserts of Assets since the current log doesn't contain much information on the incoming Asset when something goes wrong (e.g. hitting uniqueness constraint).

The full stack trace will still be available in server.log since any runtime exception is treated as a system exception (causing rollback) and Wildfly will log that automatically.

Refs: FART-538