### PR TITLE
feat: improves finding existing and merging assets

### DIFF
--- a/LIQUIBASE/changelog/db-changelog-master.xml
+++ b/LIQUIBASE/changelog/db-changelog-master.xml
@@ -48,5 +48,8 @@
     <include file="v6.7.26/db-changelog-refactor-pollbase-terminalConnect.xml" relativeToChangelogFile="true"/>
     <include file="v6.7.28/db-changelog-rename-updatetime-pollbase.xml" relativeToChangelogFile="true"/>
     <include file="v6.8.3/db-changelog-introduce-value-type-in-asset-filter.xml" relativeToChangelogFile="true"/>
+    <include file="v6.10.0/db-changelog-update-mmsi-unique-on-active.xml" relativeToChangelogFile="true"/>
+    <include file="v6.10.0/db-changelog-update-ircs-unique-on-active.xml" relativeToChangelogFile="true"/>
+    <include file="v6.10.0/db-changelog-update-national-id-unique-on-flag-state.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/LIQUIBASE/changelog/v6.10.0/db-changelog-update-ircs-unique-on-active.xml
+++ b/LIQUIBASE/changelog/v6.10.0/db-changelog-update-ircs-unique-on-active.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+                   logicalFilePath="changelog/v6.10.0/db-changelog-update-ircs-unique-on-active.xml">
+
+    <changeSet id="change ircs constraint to include flag state and active" author="johwal">
+        <dropUniqueConstraint constraintName="asset_uc_ircs" tableName="asset"/>
+
+        <sql>
+            create unique index asset_uc_ircs on asset.asset (ircs, flagstatecode) where active;
+        </sql>
+
+        <rollback>
+            <dropIndex indexName="asset_uc_ircs" tableName="asset"/>
+            <addUniqueConstraint columnNames="ircs" constraintName="asset_uc_ircs" tableName="asset"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/LIQUIBASE/changelog/v6.10.0/db-changelog-update-mmsi-unique-on-active.xml
+++ b/LIQUIBASE/changelog/v6.10.0/db-changelog-update-mmsi-unique-on-active.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+                   logicalFilePath="changelog/v6.10.0/db-changelog-update-mmsi-unique-on-active.xml">
+
+    <changeSet id="change mmsi constraint to include active" author="johwal">
+        <dropUniqueConstraint constraintName="asset_uc_mmsi" tableName="asset"/>
+
+        <sql>
+            create unique index asset_uc_mmsi on asset.asset (mmsi) where active;
+        </sql>
+
+        <rollback>
+            <dropIndex indexName="asset_uc_mmsi" tableName="asset"/>
+            <addUniqueConstraint columnNames="mmsi" constraintName="asset_uc_mmsi" tableName="asset"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/LIQUIBASE/changelog/v6.10.0/db-changelog-update-national-id-unique-on-flag-state.xml
+++ b/LIQUIBASE/changelog/v6.10.0/db-changelog-update-national-id-unique-on-flag-state.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+                   logicalFilePath="changelog/v6.10.0/db-changelog-update-national-id-unique-on-flag-state.xml">
+
+    <changeSet id="change national id constraint to include flag state and active" author="johwal">
+        <dropUniqueConstraint constraintName="asset_uc_national_id" tableName="asset"/>
+
+        <sql>
+            create unique index asset_uc_national_id on asset.asset (national_id, flagstatecode) where active;
+        </sql>
+
+        <rollback>
+            <dropIndex indexName="asset_uc_national_id" tableName="asset"/>
+            <addUniqueConstraint columnNames="national_id"
+                                 constraintName="asset_uc_national_id"
+                                 tableName="asset"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/LIQUIBASE/pom.xml
+++ b/LIQUIBASE/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.uvms.asset</groupId>
         <artifactId>asset</artifactId>
-        <version>6.9.1-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>fish.focus.uvms.asset</groupId>
         <artifactId>asset</artifactId>
-        <version>6.9.1-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.uvms.asset</groupId>
         <artifactId>asset</artifactId>
-        <version>6.9.1-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>fish.focus.uvms.asset</groupId>
         <artifactId>asset</artifactId>
-        <version>6.9.1-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/module/src/main/java/fish/focus/uvms/asset/domain/entity/Asset.java
+++ b/module/src/main/java/fish/focus/uvms/asset/domain/entity/Asset.java
@@ -12,15 +12,14 @@ import javax.json.bind.annotation.JsonbTypeSerializer;
 import javax.persistence.*;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Size;
-
-import static fish.focus.uvms.asset.domain.entity.Asset.*;
-
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import static fish.focus.uvms.asset.domain.entity.Asset.*;
 
 @Audited
 @Entity
@@ -49,10 +48,18 @@ import java.util.UUID;
         @NamedQuery(name = ASSET_FIND_BY_IDS, query = "SELECT new fish.focus.uvms.asset.dto.AssetProjection(a.id, a.historyId, a.ircsIndicator, a.ersIndicator, a.aisIndicator, a.vmsIndicator, a.hullMaterial, a.commissionDate, a.constructionYear, a.constructionPlace, a.updateTime, a.source, a.vesselType, a.vesselDateOfEntry, a.cfr, a.imo, a.ircs, a.mmsi, a.iccat, a.uvi, a.gfcm, a.active, a.flagStateCode, a.eventCode, a.name, a.externalMarking, a.agentIsAlsoOwner, a.lengthOverAll, a.lengthBetweenPerpendiculars, a.safteyGrossTonnage, a.otherTonnage, a.grossTonnage, a.grossTonnageUnit, a.portOfRegistration, a.powerOfAuxEngine, a.powerOfMainEngine, a.hasLicence, a.licenceType, a.mainFishingGearCode, a.subFishingGearCode, a.gearFishingType, a.ownerName, a.hasVms, a.ownerAddress, a.assetAgentAddress, a.countryOfImportOrExport, a.typeOfExport, a.administrativeDecisionDate, a.segment, a.segmentOfAdministrativeDecision, a.publicAid, a.registrationNumber, a.updatedBy, a.prodOrgCode, a.prodOrgName, m.id, a.comment, a.nationalId, a.parked) FROM Asset a LEFT JOIN a.mobileTerminals m WHERE a.id in :idList"),
         @NamedQuery(name = ASSET_FIND_BY_ALL_IDENTIFIERS, query = "SELECT v FROM Asset v WHERE v.cfr = :cfr OR v.ircs = :ircs OR v.imo = :imo OR v.mmsi = :mmsi OR v.iccat = :iccat OR v.uvi = :uvi OR v.gfcm = :gfcm"),
         @NamedQuery(name = ASSET_FIND_BY_MMSI_OR_IRCS, query = "SELECT a FROM Asset a WHERE (replace(a.ircs, '-', '') = :ircs OR a.mmsi = :mmsi) AND a.active = true"),
+        @NamedQuery(name = ASSET_FIND_ACTIVE_BY_ANY_ID, query = "SELECT a FROM Asset a " +
+                "WHERE (a.imo = :imo OR a.cfr = :cfr OR (a.nationalId = :nationalId and a.flagStateCode = :flagStateCode)) OR " +
+                "((a.imo is null AND a.cfr is null AND a.nationalId is null) AND (replace(a.ircs, '-', '') = :ircs OR a.mmsi = :mmsi)) AND " +
+                "a.active = true " +
+                "order by imo, cfr, national_id, ircs, mmsi nulls last"),
+        @NamedQuery(name = ASSET_FIND_BY_ANY_ID, query = "SELECT a FROM Asset a " +
+                "WHERE (a.imo = :imo OR a.cfr = :cfr OR replace(a.ircs, '-', '') = :ircs OR a.mmsi = :mmsi) AND " +
+                "a.active = true " +
+                "order by imo, cfr, national_id, ircs, mmsi nulls last"),
         @NamedQuery(name = ASSET_ALL_AVAILABLE_VESSEL_TYPES, query = "SELECT DISTINCT a.vesselType FROM Asset a"),
 })
 public class Asset implements Serializable {
-
     public static final String ASSET_FIND_BY_CFR = "Asset.findByCfr";
     public static final String ASSET_FIND_BY_IRCS = "Asset.findByIrcs";
     public static final String ASSET_FIND_BY_IMO = "Asset.findByImo";
@@ -65,6 +72,8 @@ public class Asset implements Serializable {
     public static final String ASSET_FIND_BY_IDS = "Asset.findByIds";
     public static final String ASSET_FIND_BY_ALL_IDENTIFIERS = "Asset.findByAllIds";
     public static final String ASSET_FIND_BY_MMSI_OR_IRCS = "Asset.findByMmsiOrIrcs";
+    public static final String ASSET_FIND_ACTIVE_BY_ANY_ID = "Asset.findActiveByAnyId";
+    public static final String ASSET_FIND_BY_ANY_ID = "Asset.findByAnyId";
     public static final String ASSET_ALL_AVAILABLE_VESSEL_TYPES = "Asset.allAvailableVesselTypes";
 
     private static final long serialVersionUID = -320627625723663100L;

--- a/module/src/test/java/fish/focus/uvms/asset/message/AisAssetTestHelper.java
+++ b/module/src/test/java/fish/focus/uvms/asset/message/AisAssetTestHelper.java
@@ -1,0 +1,71 @@
+package fish.focus.uvms.asset.message;
+
+import fish.focus.uvms.asset.domain.entity.Asset;
+import fish.focus.wsdl.asset.types.CarrierSource;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static fish.focus.uvms.asset.message.AssetTestHelper.getRandomIntegers;
+
+public class AisAssetTestHelper {
+
+    private AisAssetTestHelper() {
+        // hide default public constructor
+    }
+
+    public static Asset createAisStaticReport() {
+        Asset asset = new Asset();
+
+        asset.setName("Ship" + getRandomIntegers(10));
+        asset.setActive(true);
+        asset.setIrcs("I" + getRandomIntegers(7));
+        asset.setEventCode("MOD");
+        asset.setFlagStateCode("SWE");
+        asset.setMmsi(getRandomIntegers(9));
+        asset.setSource(CarrierSource.INTERNAL.value());
+        asset.setUpdatedBy("AIS Message Type 5");
+        asset.setVesselType("Fishing");
+
+        return asset;
+    }
+
+    public static Asset getNationalSourceAssetForUpsertUsingMethod() {
+        Asset nationalSourceAsset = new Asset();
+
+        nationalSourceAsset.setActive(true);
+        nationalSourceAsset.setAisIndicator(true);
+        nationalSourceAsset.setCfr("LTU" + getRandomIntegers(7));
+        nationalSourceAsset.setConstructionYear("2022");
+        nationalSourceAsset.setErsIndicator(true);
+        nationalSourceAsset.setEventCode("MOD");
+        nationalSourceAsset.setExternalMarking("EXT" + getRandomIntegers(3));
+        nationalSourceAsset.setFlagStateCode("SWE");
+        nationalSourceAsset.setGrossTonnage(1197.0);
+        nationalSourceAsset.setHasLicence(true);
+        nationalSourceAsset.setHasVms(true);
+        nationalSourceAsset.setHullMaterial("2");
+        nationalSourceAsset.setImo("0" + getRandomIntegers(6));
+        nationalSourceAsset.setIrcs("I" + getRandomIntegers(7));
+        nationalSourceAsset.setIrcsIndicator(true);
+        nationalSourceAsset.setLengthBetweenPerpendiculars(44.5);
+        nationalSourceAsset.setLengthOverAll(49.9);
+        nationalSourceAsset.setMainFishingGearCode("OTM");
+        nationalSourceAsset.setMmsi(getRandomIntegers(9));
+        nationalSourceAsset.setName("Ship" + getRandomIntegers(10));
+        nationalSourceAsset.setNationalId(ThreadLocalRandom.current().nextLong(10_000_000));
+        nationalSourceAsset.setPortOfRegistration("LTKLJ Klaipeda");
+        nationalSourceAsset.setPowerOfAuxEngine(718.0);
+        nationalSourceAsset.setPowerOfMainEngine(2666.0);
+        nationalSourceAsset.setSegment("MFL");
+        nationalSourceAsset.setSource(CarrierSource.NATIONAL.value());
+        nationalSourceAsset.setSubFishingGearCode("OTM");
+        nationalSourceAsset.setUpdatedBy("Testing code");
+        nationalSourceAsset.setVesselDateOfEntry(ZonedDateTime.now(ZoneOffset.UTC).minusYears(1).toInstant());
+        nationalSourceAsset.setVesselType("Fishing");
+        nationalSourceAsset.setVmsIndicator(true);
+
+        return nationalSourceAsset;
+    }
+}

--- a/module/src/test/java/fish/focus/uvms/asset/message/AssetEventQueueTest.java
+++ b/module/src/test/java/fish/focus/uvms/asset/message/AssetEventQueueTest.java
@@ -11,10 +11,10 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
 package fish.focus.uvms.asset.message;
 
 import fish.focus.uvms.asset.bean.AssetServiceBean;
-import fish.focus.uvms.asset.domain.constant.AssetIdentifier;
+import fish.focus.uvms.asset.dto.AssetMTEnrichmentRequest;
 import fish.focus.uvms.asset.message.event.AssetModelMapper;
 import fish.focus.uvms.asset.model.mapper.JAXBMarshaller;
-import fish.focus.uvms.tests.BuildAssetServiceDeployment;
+import fish.focus.uvms.rest.asset.AbstractAssetRestTest;
 import fish.focus.uvms.tests.asset.service.arquillian.arquillian.AssetTestsHelper;
 import fish.focus.wsdl.asset.module.AssetModuleMethod;
 import fish.focus.wsdl.asset.module.PingRequest;
@@ -28,11 +28,18 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 import javax.jms.Message;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static fish.focus.uvms.asset.domain.constant.AssetIdentifier.*;
+import static fish.focus.uvms.asset.message.AisAssetTestHelper.getNationalSourceAssetForUpsertUsingMethod;
+import static fish.focus.uvms.asset.message.AssetTestHelper.getRandomIntegers;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.*;
@@ -40,7 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 @RunWith(Arquillian.class)
-public class AssetEventQueueTest extends BuildAssetServiceDeployment {
+public class AssetEventQueueTest extends AbstractAssetRestTest {
 
     private final JMSHelper jmsHelper = new JMSHelper();
 
@@ -172,6 +179,7 @@ public class AssetEventQueueTest extends BuildAssetServiceDeployment {
                 .atMost(2, SECONDS)
                 .untilAsserted(() -> {
                     Asset assetById = jmsHelper.getAssetById(asset.getMmsiNo(), AssetIdType.MMSI);
+                    assertThat("The asset should exist after creation", assetById, is(notNullValue()));
                     assertNull(assetById.getName());
                 });
 
@@ -615,7 +623,7 @@ public class AssetEventQueueTest extends BuildAssetServiceDeployment {
 
         fish.focus.uvms.asset.domain.entity.Asset newAsset = new fish.focus.uvms.asset.domain.entity.Asset();
 
-        newAsset.setMmsi(AssetTestHelper.getRandomIntegers(9));
+        newAsset.setMmsi(getRandomIntegers(9));
         newAsset.setIrcs(asset.getIrcs());
         newAsset.setName("shouldNotBeThis");
         List<fish.focus.uvms.asset.domain.entity.Asset> assetList = new ArrayList<>();
@@ -693,9 +701,679 @@ public class AssetEventQueueTest extends BuildAssetServiceDeployment {
         await()
                 .atMost(2, SECONDS)
                 .untilAsserted(() -> {
-                    fish.focus.uvms.asset.domain.entity.Asset assetById = assetServiceBean.getAssetById(AssetIdentifier.NATIONAL, nationalId.toString());
-                    assertEquals(nationalId, assetById.getNationalId());
-                    assertEquals(asset.getName(), assetById.getName());
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(NATIONAL, nationalId.toString());
+                    assertThat("Asset should exist after creation", fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getNationalId(), is(nationalId));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void updateAssetWithOnlyNationalIdToNewFlagState() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+        asset.setName("Create with national id");
+        Long nationalId = ThreadLocalRandom.current().nextLong(10_000_000);
+        asset.setNationalId(nationalId);
+        asset.setFlagStateCode("SWE");
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(NATIONAL, nationalId.toString());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getNationalId(), is(nationalId));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat(fetchedAsset.getFlagStateCode(), is(asset.getFlagStateCode()));
+                });
+
+        asset.setFlagStateCode("NOR");
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(NATIONAL, nationalId.toString());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getNationalId(), is(nationalId));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat(fetchedAsset.getFlagStateCode(), is(asset.getFlagStateCode()));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void createNewAssetWithSameNationalIdButDifferingFlagStateTest() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+        asset.setName("Create with national id");
+        Long nationalId = ThreadLocalRandom.current().nextLong(10_000_000);
+        asset.setNationalId(nationalId);
+        asset.setFlagStateCode("SWE");
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(CFR, asset.getCfr());
+                    assertThat("Asset should exist after creation", fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getNationalId(), is(nationalId));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat(fetchedAsset.getFlagStateCode(), is(asset.getFlagStateCode()));
+                });
+
+        Asset secondBasicAsset = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset secondAsset = assetModelMapper.toAssetEntity(secondBasicAsset);
+        secondAsset.setName("Second with national id");
+        secondAsset.setNationalId(nationalId);
+        secondAsset.setFlagStateCode("NOR");
+
+        jmsHelper.upsertAssetUsingMethod(secondAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(CFR, secondAsset.getCfr());
+                    assertThat("The second asset with the same national ID should exist", fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getNationalId(), is(nationalId));
+                    assertThat(fetchedAsset.getName(), is(secondAsset.getName()));
+                    assertThat(fetchedAsset.getFlagStateCode(), is(secondAsset.getFlagStateCode()));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void creatingNewActiveAssetInactivatingAndActivatingShouldWorkTest() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+
+        asset.setActive(true);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be active after creation", fetchedAsset.getActive(), is(true));
+                });
+
+        asset.setActive(false);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be inactive after update", fetchedAsset.getActive(), is(false));
+                });
+
+        asset.setActive(true);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be active after update", fetchedAsset.getActive(), is(true));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void creatingNewActiveAssetWithSameMmsiFromOtherActiveAssetShouldFailTest() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+        asset.setName("First MMSI vessel");
+        asset.setActive(true);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be active after creation", fetchedAsset.getActive(), is(true));
+                });
+
+        Asset otherBasicAsset = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset otherAsset = assetModelMapper.toAssetEntity(otherBasicAsset);
+        otherAsset.setName("Second MMSI vessel");
+        otherAsset.setActive(true);
+        otherAsset.setMmsi(asset.getMmsi());
+
+        jmsHelper.upsertAssetUsingMethod(otherAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, asset.getCfr());
+                    assertThat("First active vessel should still exist after trying to add second active vessel with same MMSI",
+                            firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(firstFetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(firstFetchedAsset.getName(), is(asset.getName()));
+                    assertThat("First asset should still be active after trying to create a second active asset",
+                            firstFetchedAsset.getActive(), is(true));
+
+                    fish.focus.uvms.asset.domain.entity.Asset secondFetchedAsset = assetServiceBean.getAssetById(CFR, otherAsset.getCfr());
+                    assertThat(secondFetchedAsset, is(nullValue()));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void createNewActiveAssetWithMmsiFromInactiveAssetTest() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+        asset.setName("First MMSI vessel");
+        asset.setActive(true);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be active after creation", fetchedAsset.getActive(), is(true));
+                });
+
+        asset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(MMSI, asset.getMmsi());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be inactive after update", fetchedAsset.getActive(), is(false));
+                });
+
+        Asset otherBasicAsset = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset otherAsset = assetModelMapper.toAssetEntity(otherBasicAsset);
+        otherAsset.setName("Second MMSI vessel");
+        otherAsset.setActive(true);
+        otherAsset.setMmsi(asset.getMmsi());
+
+        jmsHelper.upsertAssetUsingMethod(otherAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, asset.getCfr());
+                    assertThat("The first vessel should still exist", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getMmsi(), is(asset.getMmsi()));
+                    assertThat("The first vessel should still be inactive", firstFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset otherFetchedAsset = assetServiceBean.getAssetById(CFR, otherAsset.getCfr());
+                    assertThat("A new active vessel should be able to reuse MMSI from inactive vessel", otherFetchedAsset, is(notNullValue()));
+                    assertThat(otherFetchedAsset.getCfr(), is(not(asset.getCfr())));
+                    assertThat(otherFetchedAsset.getCfr(), is(otherAsset.getCfr()));
+
+                    assertThat(otherFetchedAsset.getMmsi(), is(otherAsset.getMmsi()));
+
+                    assertThat(otherFetchedAsset.getName(), is(otherAsset.getName()));
+                    assertThat("The second vessel should be active", otherFetchedAsset.getActive(), is(true));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void createOneActiveAssetAndTwoInactiveAssetsWithSameMmsiTest() throws Exception {
+        // Assets are hardcoded to be active upon creation
+        Asset firstAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset firstInactiveAsset = assetModelMapper.toAssetEntity(firstAssetType);
+        firstInactiveAsset.setName("First MMSI vessel");
+        firstInactiveAsset.setActive(true);
+
+        String mmsi = firstInactiveAsset.getMmsi();
+
+        jmsHelper.upsertAssetUsingMethod(firstInactiveAsset);
+        verifyAssetMmsiNameAndActive(firstInactiveAsset, mmsi, "First asset should be active after creation", true);
+
+        firstInactiveAsset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(firstInactiveAsset);
+        verifyAssetMmsiNameAndActive(firstInactiveAsset, mmsi, "First asset should be inactive after update", false);
+
+        Asset secondInactiveAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset secondInactiveAsset = assetModelMapper.toAssetEntity(secondInactiveAssetType);
+        secondInactiveAsset.setName("Second MMSI vessel");
+        secondInactiveAsset.setActive(true);
+        secondInactiveAsset.setMmsi(mmsi);
+
+        jmsHelper.upsertAssetUsingMethod(secondInactiveAsset);
+        verifyAssetMmsiNameAndActive(secondInactiveAsset, mmsi, "Second asset should be active after creation", true);
+
+        secondInactiveAsset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(secondInactiveAsset);
+        verifyAssetMmsiNameAndActive(secondInactiveAsset, mmsi, "Second asset should be inactive after update", false);
+
+        Asset activeAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset activeAsset = assetModelMapper.toAssetEntity(activeAssetType);
+        activeAsset.setName("Active MMSI vessel");
+        activeAsset.setActive(true);
+        activeAsset.setMmsi(mmsi);
+
+        jmsHelper.upsertAssetUsingMethod(activeAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstInactiveFetchedAsset = assetServiceBean.getAssetById(CFR, firstInactiveAsset.getCfr());
+                    assertThat("The first vessel should still exist", firstInactiveFetchedAsset, is(notNullValue()));
+                    assertThat(firstInactiveFetchedAsset.getMmsi(), is(mmsi));
+                    assertThat("The first vessel should still be inactive", firstInactiveFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset secondInactiveFetchedAsset = assetServiceBean.getAssetById(CFR, secondInactiveAsset.getCfr());
+                    assertThat("The second vessel should still exist", secondInactiveFetchedAsset, is(notNullValue()));
+                    assertThat(secondInactiveFetchedAsset.getMmsi(), is(mmsi));
+                    assertThat("The second vessel should still be inactive", secondInactiveFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedActiveAsset = assetServiceBean.getAssetById(CFR, activeAsset.getCfr());
+                    assertThat("A new active vessel should be able to reuse MMSI from inactive vessel", fetchedActiveAsset, is(notNullValue()));
+                    assertThat(fetchedActiveAsset.getCfr(), is(not(firstInactiveAsset.getCfr())));
+                    assertThat(fetchedActiveAsset.getCfr(), is(not(secondInactiveAsset.getCfr())));
+                    assertThat(fetchedActiveAsset.getCfr(), is(activeAsset.getCfr()));
+
+                    assertThat(fetchedActiveAsset.getMmsi(), is(mmsi));
+
+                    assertThat(fetchedActiveAsset.getName(), is(activeAsset.getName()));
+                    assertThat("The last created vessel should be active", fetchedActiveAsset.getActive(), is(true));
+                });
+    }
+
+    private void verifyAssetMmsiNameAndActive(fish.focus.uvms.asset.domain.entity.Asset firstInactiveAsset, String mmsi, String reason, boolean value) {
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(CFR, firstInactiveAsset.getCfr());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getMmsi(), is(mmsi));
+                    assertThat(fetchedAsset.getName(), is(firstInactiveAsset.getName()));
+                    assertThat(reason, fetchedAsset.getActive(), is(value));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void createNewActiveAssetWithIrcsFromInactiveAssetTest() throws Exception {
+        Asset assetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset asset = assetModelMapper.toAssetEntity(assetType);
+        asset.setName("First IRCS vessel");
+        asset.setActive(true);
+
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(IRCS, asset.getIrcs());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getIrcs(), is(asset.getIrcs()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be active after creation", fetchedAsset.getActive(), is(true));
+                });
+
+        asset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(asset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(IRCS, asset.getIrcs());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getCfr(), is(asset.getCfr()));
+                    assertThat(fetchedAsset.getIrcs(), is(asset.getIrcs()));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat("Asset should be inactive after update", fetchedAsset.getActive(), is(false));
+                });
+
+        Asset otherBasicAsset = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset otherAsset = assetModelMapper.toAssetEntity(otherBasicAsset);
+        otherAsset.setName("Second MMSI vessel");
+        otherAsset.setActive(true);
+        otherAsset.setIrcs(asset.getIrcs());
+
+        jmsHelper.upsertAssetUsingMethod(otherAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, asset.getCfr());
+                    assertThat("The first vessel should still exist", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getIrcs(), is(asset.getIrcs()));
+                    assertThat("The first vessel should still be inactive", firstFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset otherFetchedAsset = assetServiceBean.getAssetById(CFR, otherAsset.getCfr());
+                    assertThat("A new active vessel should be able to reuse IRCS from inactive vessel", otherFetchedAsset, is(notNullValue()));
+                    assertThat(otherFetchedAsset.getCfr(), is(not(asset.getCfr())));
+                    assertThat(otherFetchedAsset.getCfr(), is(otherAsset.getCfr()));
+
+                    assertThat(otherFetchedAsset.getIrcs(), is(otherAsset.getIrcs()));
+
+                    assertThat(otherFetchedAsset.getName(), is(otherAsset.getName()));
+                    assertThat("The second vessel should be active", otherFetchedAsset.getActive(), is(true));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void creatingTwoAssetsWithNullIrcsShouldWorkTest() throws Exception {
+        Asset firstAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset firstAsset = assetModelMapper.toAssetEntity(firstAssetType);
+        firstAsset.setName("First IRCS vessel");
+        firstAsset.setIrcs(null);
+
+        jmsHelper.upsertAssetUsingMethod(firstAsset);
+        verifyAssetIrcsNameAndActive(firstAsset, null, "First asset should exist after creation", true);
+
+        Asset secondAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset secondAsset = assetModelMapper.toAssetEntity(secondAssetType);
+        secondAsset.setName("Second IRCS vessel");
+        secondAsset.setIrcs(null);
+
+        jmsHelper.upsertAssetUsingMethod(secondAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, firstAsset.getCfr());
+                    assertThat("The first asset should exist", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getIrcs(), is(nullValue()));
+
+                    fish.focus.uvms.asset.domain.entity.Asset secondFetchedAsset = assetServiceBean.getAssetById(CFR, secondAsset.getCfr());
+                    assertThat("The second asset should exist", secondFetchedAsset, is(notNullValue()));
+                    assertThat(secondFetchedAsset.getIrcs(), is(nullValue()));
+
+                    assertThat(firstFetchedAsset.getCfr(), is(not(secondFetchedAsset.getCfr())));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void createOneActiveAssetAndTwoInactiveAssetsWithSameIrcsTest() throws Exception {
+        // Assets are hardcoded to be active upon creation
+        Asset firstAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset firstInactiveAsset = assetModelMapper.toAssetEntity(firstAssetType);
+        firstInactiveAsset.setName("First IRCS vessel");
+        firstInactiveAsset.setActive(true);
+
+        String ircs = firstInactiveAsset.getIrcs();
+
+        jmsHelper.upsertAssetUsingMethod(firstInactiveAsset);
+        verifyAssetIrcsNameAndActive(firstInactiveAsset, ircs, "First asset should be active after creation", true);
+
+        firstInactiveAsset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(firstInactiveAsset);
+        verifyAssetIrcsNameAndActive(firstInactiveAsset, ircs, "First asset should be inactive after update", false);
+
+        Asset secondInactiveAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset secondInactiveAsset = assetModelMapper.toAssetEntity(secondInactiveAssetType);
+        secondInactiveAsset.setName("Second IRCS vessel");
+        secondInactiveAsset.setActive(true);
+        secondInactiveAsset.setIrcs(ircs);
+
+        jmsHelper.upsertAssetUsingMethod(secondInactiveAsset);
+        verifyAssetIrcsNameAndActive(secondInactiveAsset, ircs, "Second asset should be active after creation", true);
+
+        secondInactiveAsset.setActive(false);
+        jmsHelper.upsertAssetUsingMethod(secondInactiveAsset);
+        verifyAssetIrcsNameAndActive(secondInactiveAsset, ircs, "Second asset should be inactive after update", false);
+
+        Asset activeAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset activeAsset = assetModelMapper.toAssetEntity(activeAssetType);
+        activeAsset.setName("Active IRCS vessel");
+        activeAsset.setActive(true);
+        activeAsset.setIrcs(ircs);
+
+        jmsHelper.upsertAssetUsingMethod(activeAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstInactiveFetchedAsset = assetServiceBean.getAssetById(CFR, firstInactiveAsset.getCfr());
+                    assertThat("The first vessel should still exist", firstInactiveFetchedAsset, is(notNullValue()));
+                    assertThat(firstInactiveFetchedAsset.getIrcs(), is(ircs));
+                    assertThat("The first vessel should still be inactive", firstInactiveFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset secondInactiveFetchedAsset = assetServiceBean.getAssetById(CFR, secondInactiveAsset.getCfr());
+                    assertThat("The second vessel should still exist", secondInactiveFetchedAsset, is(notNullValue()));
+                    assertThat(secondInactiveFetchedAsset.getIrcs(), is(ircs));
+                    assertThat("The second vessel should still be inactive", secondInactiveFetchedAsset.getActive(), is(false));
+
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedActiveAsset = assetServiceBean.getAssetById(CFR, activeAsset.getCfr());
+                    assertThat("A new active vessel should be able to reuse IRCS from inactive vessel", fetchedActiveAsset, is(notNullValue()));
+                    assertThat(fetchedActiveAsset.getCfr(), is(not(firstInactiveAsset.getCfr())));
+                    assertThat(fetchedActiveAsset.getCfr(), is(not(secondInactiveAsset.getCfr())));
+                    assertThat(fetchedActiveAsset.getCfr(), is(activeAsset.getCfr()));
+
+                    assertThat(fetchedActiveAsset.getIrcs(), is(ircs));
+
+                    assertThat(fetchedActiveAsset.getName(), is(activeAsset.getName()));
+                    assertThat("The last created vessel should be active", fetchedActiveAsset.getActive(), is(true));
+                });
+    }
+
+    private void verifyAssetIrcsNameAndActive(fish.focus.uvms.asset.domain.entity.Asset asset, String ircs, String reason, boolean value) {
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAsset = assetServiceBean.getAssetById(CFR, asset.getCfr());
+                    assertThat(fetchedAsset, is(notNullValue()));
+                    assertThat(fetchedAsset.getIrcs(), is(ircs));
+                    assertThat(fetchedAsset.getName(), is(asset.getName()));
+                    assertThat(reason, fetchedAsset.getActive(), is(value));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void updateAisStaticReportEntryWithNationalDataTest() throws Exception {
+        fish.focus.uvms.asset.domain.entity.Asset aisAsset = AisAssetTestHelper.createAisStaticReport();
+        String flagState = "LTU";
+        aisAsset.setFlagStateCode(flagState);
+
+        String ircs = aisAsset.getIrcs();
+        String mmsi = aisAsset.getMmsi();
+        String name = aisAsset.getName();
+
+        createAssetThroughAisMovementFlow(name, flagState, ircs, mmsi);
+
+        jmsHelper.updateAssetInfo(List.of(aisAsset));
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset fetchedAssetByIrcs = assetServiceBean.getAssetById(IRCS, ircs);
+                    assertThat("The vessel should have been created", fetchedAssetByIrcs, is(notNullValue()));
+                    assertThat(fetchedAssetByIrcs.getIrcs(), is(ircs));
+                    assertThat(fetchedAssetByIrcs.getMmsi(), is(mmsi));
+                    assertThat(fetchedAssetByIrcs.getCfr(), is(nullValue()));
+                    assertThat(fetchedAssetByIrcs.getImo(), is(nullValue()));
+                    assertThat(fetchedAssetByIrcs.getNationalId(), is(nullValue()));
+                    assertThat(fetchedAssetByIrcs.getActive(), is(true));
+                    assertThat(fetchedAssetByIrcs.getVesselType(), is("Fishing"));
+                });
+
+        fish.focus.uvms.asset.domain.entity.Asset nationalSourceAsset = getNationalSourceAssetForUpsertUsingMethod();
+        nationalSourceAsset.setIrcs(ircs);
+        nationalSourceAsset.setMmsi(mmsi);
+        nationalSourceAsset.setFlagStateCode(flagState);
+
+        jmsHelper.upsertAssetUsingMethod(nationalSourceAsset);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, nationalSourceAsset.getCfr());
+                    assertThat(firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getIrcs(), is(ircs));
+                    assertThat(firstFetchedAsset.getActive(), is(true));
+                });
+    }
+
+    private void createAssetThroughAisMovementFlow(String name, String flagState, String ircs, String mmsi) {
+        createAssetThroughAisMovementFlow(name, flagState, ircs, mmsi, null);
+    }
+
+    private void createAssetThroughAisMovementFlow(String name, String flagState, String ircs, String mmsi, String cfr) {
+        // AIS static reports can not be created, only updated
+        // A real version of this would have MovementModule creating the new asset when fetching MT
+        // AIS position -> movement module -> get MT -> create new unknown asset
+        AssetMTEnrichmentRequest request = new AssetMTEnrichmentRequest();
+        request.setAssetName(name);
+        request.setFlagState(flagState);
+        request.setIrcsValue(ircs);
+        request.setMmsiValue(mmsi);
+        request.setCfrValue(cfr);
+
+        Response response = getWebTargetInternal()
+                .path("internal")
+                .path("collectassetmt")
+                .request(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, getTokenInternalRest())
+                .post(Entity.json(request), Response.class);
+
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void entryFromAisMovementFlowShouldBeMergedAndRemappedUponNationalSourceUpdate() throws Exception {
+        // Scenario: Asset exists in DB
+        // new MMSI, starts sending AIS positions
+        // AIS position -> movement module -> get MT -> create new unknown asset since mmsi doesn't exist in database
+        // (sync from national source hasn't happened yet)
+        // Later sync from national source happens with updated mmsi, finds match on e.g. cfr
+        // tries to update, old version fails due to mmsi collision
+        // What should happen is the Unknown AIS entry with same mmsi is nulled out and any positions are remapped
+        // i.e. there should only be one "real" entry in the db for the asset, not several half entries
+
+        Asset firstAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset assetFromNationalSource = assetModelMapper.toAssetEntity(firstAssetType);
+        assetFromNationalSource.setName("Asset from national source");
+        assetFromNationalSource.setSource(CarrierSource.NATIONAL.value());
+
+        String oldMmsi = assetFromNationalSource.getMmsi();
+        String cfr = assetFromNationalSource.getCfr();
+        String ircs = assetFromNationalSource.getIrcs();
+
+        jmsHelper.upsertAssetUsingMethod(assetFromNationalSource);
+        verifyAssetMmsiNameAndActive(assetFromNationalSource, oldMmsi, "First asset should be active after creation", true);
+
+        // Asset from national source should now exist
+        // introduce new mmsi and fake the AIS movement flow
+
+        String flagState = assetFromNationalSource.getFlagStateCode();
+        String newMmsi = getRandomIntegers(9);
+
+        createAssetThroughAisMovementFlow("Unknown: 4328", flagState, null, newMmsi);
+
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(MMSI, newMmsi);
+                    assertThat("Asset should exist after creation using the AIS movement flow", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getIrcs(), is(nullValue()));
+                    assertThat(firstFetchedAsset.getCfr(), is(nullValue()));
+                });
+
+        // Send national source update with the updated mmsi
+        assetFromNationalSource.setMmsi(newMmsi);
+
+        jmsHelper.upsertAssetUsingMethod(assetFromNationalSource);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(MMSI, newMmsi);
+                    assertThat("Should only be one entry per mmsi", firstFetchedAsset, is(notNullValue()));
+
+                    fish.focus.uvms.asset.domain.entity.Asset secondFetchedAsset = assetServiceBean.getAssetById(CFR, cfr);
+                    assertThat(secondFetchedAsset, is(notNullValue()));
+                    assertThat(secondFetchedAsset.getIrcs(), is(ircs));
+
+                    assertThat("The assets should be the same after the update", firstFetchedAsset.getCfr(), is(secondFetchedAsset.getCfr()));
+                });
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void twoEntriesFromAisMovementFlowShouldBeMergedAndRemappedUponNationalSourceUpdate() throws Exception {
+        // Scenario: National sync has not happened yet
+        // Vessel is configuring sending equipment but not all values are set and starts sending
+        // e.g. first mmsi is configured and a position is sent
+        // next only ircs is configured and position is sent
+        // AIS position -> movement module -> get MT -> create new unknown asset since the values doesn't exist in database
+        // Later sync from national source happens, finds match on e.g. cfr
+        // tries to update, due to ID collision
+        // What should happen is the Unknown AIS entries with same mmsi/ircs is nulled out, merged and any positions are remapped
+        // i.e. there should only be one "real" entry in the db for the asset, not several half entries
+
+        String flagState = "SWE";
+        String mmsi = getRandomIntegers(9);
+        String ircs = "I" + getRandomIntegers(7);
+        String cfr = "CFR" + getRandomIntegers(7);
+
+        createAssetThroughAisMovementFlow("Unknown: 9934", flagState, ircs, null);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(IRCS, ircs);
+                    assertThat("Asset with IRCS only should exist after creation using the AIS movement flow", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getMmsi(), is(nullValue()));
+                    assertThat(firstFetchedAsset.getCfr(), is(nullValue()));
+                });
+
+        createAssetThroughAisMovementFlow("Unknown: 8047", flagState, null, mmsi, cfr);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset firstFetchedAsset = assetServiceBean.getAssetById(CFR, cfr);
+                    assertThat("Asset with MMSI and CFR should exist after creation using the AIS movement flow", firstFetchedAsset, is(notNullValue()));
+                    assertThat(firstFetchedAsset.getMmsi(), is(mmsi));
+                    assertThat(firstFetchedAsset.getIrcs(), is(nullValue()));
+                });
+
+        // Two internal entries now exists
+        // Fake sync from national source
+        // One of the two internal entries is kept and then updated with information from the national source asset
+
+        Asset firstAssetType = AssetTestHelper.createBasicAsset();
+        fish.focus.uvms.asset.domain.entity.Asset assetFromNationalSource = assetModelMapper.toAssetEntity(firstAssetType);
+        assetFromNationalSource.setName("Asset from national source");
+        assetFromNationalSource.setSource(CarrierSource.NATIONAL.value());
+        assetFromNationalSource.setCfr(cfr);
+        assetFromNationalSource.setIrcs(ircs);
+        assetFromNationalSource.setMmsi(mmsi);
+
+        jmsHelper.upsertAssetUsingMethod(assetFromNationalSource);
+        await()
+                .atMost(2, SECONDS)
+                .untilAsserted(() -> {
+                    fish.focus.uvms.asset.domain.entity.Asset assetByMmsi = assetServiceBean.getAssetById(MMSI, mmsi);
+                    assertThat("Should only be one entry per mmsi", assetByMmsi, is(notNullValue()));
+
+                    fish.focus.uvms.asset.domain.entity.Asset assetByIrcs = assetServiceBean.getAssetById(IRCS, ircs);
+                    assertThat("Should only be one entry per ircs", assetByIrcs, is(notNullValue()));
+
+                    fish.focus.uvms.asset.domain.entity.Asset assetByCfr = assetServiceBean.getAssetById(CFR, cfr);
+                    assertThat("Asset by cfr should have IRCS set after update", assetByCfr.getIrcs(), is(ircs));
+
+                    assertThat("The assets should be the same after the update", assetByMmsi.getCfr(), is(assetByCfr.getCfr()));
+                    assertThat("The assets should be the same after the update", assetByIrcs.getCfr(), is(assetByCfr.getCfr()));
+                    assertThat("The asset entry should've been update with national ID", assetByCfr.getNationalId(), is(assetFromNationalSource.getNationalId()));
                 });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fish.focus.uvms.asset</groupId>
     <artifactId>asset</artifactId>
-    <version>6.9.1-SNAPSHOT</version>
+    <version>6.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
Adds support for finding existing assets based on IMO and National ID.

Adds support for multiple inactive vessels with same ircs/mmsi, but only one active vessel (partial index). In addition, IRCS and National ID is now unique on flagstatecode.

Moves parts of the find existing asset logic to SQL instead.

Normalize asset now supports merging more than one asset and is also used for national source updates (i.e. not only AIS flow).

Adds logging of number of remapped positions.

Refs: FART-538