### PR TITLE
fix: changes log info to debug for asset updates

### DIFF
--- a/module/src/main/java/fish/focus/uvms/asset/message/MessageConsumerBean.java
+++ b/module/src/main/java/fish/focus/uvms/asset/message/MessageConsumerBean.java
@@ -63,13 +63,13 @@ public class MessageConsumerBean implements MessageListener {
         try {
             String propertyMethod = textMessage.getStringProperty("METHOD");
             if (propertyMethod != null && propertyMethod.equals("UPSERT_ASSET")) {
-                LOG.info("Message received in AssetModule with METHOD = {}", propertyMethod);
+                LOG.debug("Message received in AssetModule with METHOD = {}", propertyMethod);
                 assetJsonBean.upsertAsset(textMessage);
                 return;
             }
             String propertyFunction = textMessage.getStringProperty(MessageConstants.JMS_FUNCTION_PROPERTY);
             if (propertyFunction != null && propertyFunction.equals("ASSET_INFORMATION")) {
-                LOG.info("Message received in AssetModule with FUNCTION = {}", propertyFunction);
+                LOG.debug("Message received in AssetModule with FUNCTION = {}", propertyFunction);
                 assetJsonBean.updateAssetInformation(textMessage);
                 return;
             }


### PR DESCRIPTION
Asset log is filled up with the following line:
"Message received in AssetModule with METHOD = UPSERT_ASSET"

The line doesn't carry any info on which asset is being updated so is better kept as a debug option.