### PR TITLE
fix: allows MMSI null values on update

### DIFF
--- a/module/src/main/java/fish/focus/uvms/asset/bean/AssetServiceBean.java
+++ b/module/src/main/java/fish/focus/uvms/asset/bean/AssetServiceBean.java
@@ -245,7 +245,6 @@ public class AssetServiceBean {
             asset.setId(existingAsset.getId());
 
             // to save values we already have and don't get from the external source
-            asset.setMmsi(asset.getMmsi() == null ? existingAsset.getMmsi() : asset.getMmsi());
             asset.setComment(asset.getComment() == null ? existingAsset.getComment() : asset.getComment());
             asset.setParked(asset.getParked() == null ? existingAsset.getParked() : asset.getParked());
         }

--- a/module/src/test/java/fish/focus/uvms/rest/asset/service/InternalRestResourceTest.java
+++ b/module/src/test/java/fish/focus/uvms/rest/asset/service/InternalRestResourceTest.java
@@ -226,7 +226,7 @@ public class InternalRestResourceTest extends AbstractAssetRestTest {
 
     @Test
     @OperateOnDeployment("normal")
-    public void updateAssetRetainMMSIAndCommentTest() {
+    public void updateAssetRetainCommentTest() {
         Asset asset = AssetHelper.createBasicAsset();
         asset.setComment("Update Asset Retain Comment");
         AssetBO assetBo = new AssetBO();
@@ -253,7 +253,7 @@ public class InternalRestResourceTest extends AbstractAssetRestTest {
 
         assertThat(updatedAsset, is(notNullValue()));
         assertThat(updatedAsset.getAsset().getComment(), is(asset.getComment()));
-        assertThat(updatedAsset.getAsset().getMmsi(), is(asset.getMmsi()));
+        assertThat(updatedAsset.getAsset().getMmsi(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Removing MMSI from a vessel is impossible without manual intervention.